### PR TITLE
Automatically integrate version in docs baseUrl

### DIFF
--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -34,6 +34,14 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
 )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/mkdocs/mkdocs.yml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/mkdocs/mkdocs.yml
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/doxybook/config.json.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/doxybook/config.json
+)
 
 option(KDBindings_DOCS_BUILD_HTML "Whether to compile the documentation files to HTML" OFF)
 
@@ -46,7 +54,7 @@ add_custom_target(docs
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/LICENSES/MIT.txt ${DOXYGEN_OUTPUT_DIR}/mkdocs/docs/license.md
 
   # Run Doxybook2 to generate mkdocs compatible documentation
-  COMMAND ${DOXYBOOK2_EXECUTABLE} --config "${CMAKE_CURRENT_SOURCE_DIR}/doxybook/config.json" --input "${DOXYGEN_OUTPUT_DIR}/xml" --output "${DOXYGEN_OUTPUT_DIR}/mkdocs/docs"
+  COMMAND ${DOXYBOOK2_EXECUTABLE} --config "${CMAKE_CURRENT_BINARY_DIR}/doxybook/config.json" --input "${DOXYGEN_OUTPUT_DIR}/xml" --output "${DOXYGEN_OUTPUT_DIR}/mkdocs/docs"
 
   # Run MkDocs to build html documentation
   COMMAND ${MKDOCS_EXECUTABLE} build --config-file "${DOXYGEN_OUTPUT_DIR}/mkdocs/mkdocs.yml" --site-dir "${DOXYGEN_OUTPUT_DIR}/html"

--- a/docs/api/doxybook/config.json.cmake
+++ b/docs/api/doxybook/config.json.cmake
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "/docs/kdbindings/",
+  "baseUrl": "/kdbindings/${CMAKE_PROJECT_VERSION}/",
   "indexInFolders": false,
   "linkSuffix": "/",
   "mainPageInRoot": true,

--- a/docs/api/mkdocs/mkdocs.yml.cmake
+++ b/docs/api/mkdocs/mkdocs.yml.cmake
@@ -1,5 +1,5 @@
 site_name: KDBindings - Bindings from the comfort and speed of C++
-site_url: https://docs.kdab.com/kdbindings/latest/
+site_url: https://docs.kdab.com/kdbindings/${CMAKE_PROJECT_VERSION}/
 repo_url: https://github.com/kdab/kdbindings
 site_description: KDBindings Documentation - Bindings from the comfort and speed of C++
 site_author: Klarälvdalens Datakonsult AB (KDAB)


### PR DESCRIPTION
This change uses CMake's "configure_file" command to enter the current KDBindings version number into the baseUrl used by mkdocs as well as doxybook2.

This should fix the links for on docs.kdab.com.