### PR TITLE
Hotfix: Fix example06 code rendering in docs

### DIFF
--- a/src/kdbindings/binding_evaluator.h
+++ b/src/kdbindings/binding_evaluator.h
@@ -156,6 +156,7 @@ public:
  *
  * This feature is especially useful to reduce the performance impact of
  * bindings and to create bindings that only update in specific intervals.
- *
- *
+ * <br/><!-- This <br/> is a workaround for a bug in doxybook2 that causes
+ * the rendering of the example code to break because it is missing a
+ * newline-->
  */


### PR DESCRIPTION
This is a workaround for a bug in doxybook2 that causes incorrect rendering
of examples when they do not end in a code block.