### PR TITLE
doxybook: Set settings to generate relative links

### DIFF
--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -38,12 +38,6 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/mkdocs/mkdocs.yml.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/mkdocs/mkdocs.yml
 )
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/doxybook/config.json.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/doxybook/config.json
-)
-
-option(KDBindings_DOCS_BUILD_HTML "Whether to compile the documentation files to HTML" OFF)
 
 add_custom_target(docs
   # Execute Doxygen
@@ -54,7 +48,7 @@ add_custom_target(docs
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/LICENSES/MIT.txt ${DOXYGEN_OUTPUT_DIR}/mkdocs/docs/license.md
 
   # Run Doxybook2 to generate mkdocs compatible documentation
-  COMMAND ${DOXYBOOK2_EXECUTABLE} --config "${CMAKE_CURRENT_BINARY_DIR}/doxybook/config.json" --input "${DOXYGEN_OUTPUT_DIR}/xml" --output "${DOXYGEN_OUTPUT_DIR}/mkdocs/docs"
+  COMMAND ${DOXYBOOK2_EXECUTABLE} --config "${CMAKE_CURRENT_SOURCE_DIR}/doxybook/config.json" --input "${DOXYGEN_OUTPUT_DIR}/xml" --output "${DOXYGEN_OUTPUT_DIR}/mkdocs/docs"
 
   # Run MkDocs to build html documentation
   COMMAND ${MKDOCS_EXECUTABLE} build --config-file "${DOXYGEN_OUTPUT_DIR}/mkdocs/mkdocs.yml" --site-dir "${DOXYGEN_OUTPUT_DIR}/html"

--- a/docs/api/doxybook/config.json
+++ b/docs/api/doxybook/config.json
@@ -1,7 +1,8 @@
 {
-  "baseUrl": "/kdbindings/${CMAKE_PROJECT_VERSION}/",
+  "baseUrl": "",
+  "useFolders": false,
   "indexInFolders": false,
-  "linkSuffix": "/",
+  "linkSuffix": ".md",
   "mainPageInRoot": true,
   "mainPageName": "index",
   "filesFilter": [".h", ".hpp", ".cpp"],

--- a/docs/api/mkdocs/docs/getting-started/data-binding.md
+++ b/docs/api/mkdocs/docs/getting-started/data-binding.md
@@ -9,7 +9,7 @@ The basis for Data Binding in KDBindings is formed by [Properties](properties.md
 They can be combined using arithmetic operators or just plain functions, to create new properties that are bound to the input properties.
 This means the result of the calculation will be updated automatically every time the input of the calculation changes.
 
-To create a binding, use the free [makeBoundProperty](../Namespaces/namespaceKDBindings.md#function-makeboundproperty) function in the KDBindings namespace.
+To create a binding, use the free [makeBoundProperty](../namespaceKDBindings.md#function-makeboundproperty) function in the KDBindings namespace.
 
 ### Example
 ``` cpp
@@ -30,7 +30,7 @@ Pretty much all arithmetic operators are supported, as well as combinations of P
 
 ## Declaring functions for use in data binding
 KDBindings also allows you to declare arbitrary functions as usable in the context of data binding.
-See the [`node_functions.h`](../Files/node__functions_8h.md) file for documentation on the associated macros.
+See the [`node_functions.h`](../node__functions_8h.md) file for documentation on the associated macros.
 
 This is already done for some of the `std` arithmetic functions, like abs and floor.
 You can use the KDBINDINGS_DECLARE_STD_FUNCTION macro to declare more of these when necessary.
@@ -48,7 +48,7 @@ Property<int> positiveValue = makeBoundProperty(abs(value));
 
 
 ## Binding arbitrary functions
-[makeBoundProperty](../Namespaces/namespaceKDBindings.md#function-makeboundproperty) also accepts functions as binding, so arbitrary code can be executed to produce the new property value.
+[makeBoundProperty](../namespaceKDBindings.md#function-makeboundproperty) also accepts functions as binding, so arbitrary code can be executed to produce the new property value.
 
 ### Example
 ``` cpp
@@ -92,13 +92,13 @@ Property<int> result = makeBoundProperty(2 * value);
 result = 5; // this will throw a KDBindings::ReadOnlyProperty error!
 ```
 
-To intentionally remove a binding from a property, use its [`reset`](../../Classes/classKDBindings_1_1Property/#function-reset) function.
+To intentionally remove a binding from a property, use its [`reset`](../../classKDBindings_1_1Property/#function-reset) function.
 
 ### Reassigning a Binding
 Even though KDBindings prevents you from accidentally overriding a binding with a concrete value, assigning a
 new binding to a Property with an existing binding is possible.
 
-For this, use the [makeBinding](../Namespaces/namespaceKDBindings.md#function-makebinding) function instead of [makeBoundProperty](../Namespaces/namespaceKDBindings.md#function-makeboundproperty) to create the binding.
+For this, use the [makeBinding](../namespaceKDBindings.md#function-makebinding) function instead of [makeBoundProperty](../namespaceKDBindings.md#function-makeboundproperty) to create the binding.
 
 It is also possible to use makeBoundProperty, which will move-assign a new Property into the existing one, therefore completely replacing the existing Property with a new one.
 This means that all signals of the old property will be disconnected (see [signals & slots](signals-slots.md)) and any existing data bindings that depended on the property will be removed, which might not be what you want!
@@ -126,18 +126,18 @@ result = makeBoundProperty(4 * value); // This works too, but will override all 
 ## Deferred evaluation
 KDBindings optionally offers data bindings with controlled, deferred evaluation.
 
-This feature is enabled by passing a [KDBindings::BindingEvaluator](../Classes/classKDBindings_1_1BindingEvaluator.md) to makeBoundProperty.
-The binding will then only be evaluated when [`evaluateAll()`](../Classes/classKDBindings_1_1BindingEvaluator.md#function-evaluateall) is called on the evaluator instance.
+This feature is enabled by passing a [KDBindings::BindingEvaluator](../classKDBindings_1_1BindingEvaluator.md) to makeBoundProperty.
+The binding will then only be evaluated when [`evaluateAll()`](../classKDBindings_1_1BindingEvaluator.md#function-evaluateall) is called on the evaluator instance.
 
 Deferred evaluation is useful to avoid unnecessary reevaluation of a binding, as well as controlling the frequency of binding evaluation.
 Especially in UI applications, only updating the displayed values once per second can help in making them readable, compared to a bunch of values updating at 60Hz.
 
-See the [06-lazy-property-bindings](../Examples/06-lazy-property-bindings_2main_8cpp-example.md) example for more details on how to use deferred evaluation.
+See the [06-lazy-property-bindings](../06-lazy-property-bindings_2main_8cpp-example.md) example for more details on how to use deferred evaluation.
 
 
 ## Further reading
-Classes involved in data binding are [KDBindings::Property](../Classes/classKDBindings_1_1Property.md), [KDBindings::Binding](../Classes/classKDBindings_1_1Binding.md), and [KDBindings::BindingEvaluator](../Classes/classKDBindings_1_1BindingEvaluator.md).
+Classes involved in data binding are [KDBindings::Property](../classKDBindings_1_1Property.md), [KDBindings::Binding](../classKDBindings_1_1Binding.md), and [KDBindings::BindingEvaluator](../classKDBindings_1_1BindingEvaluator.md).
 
-See [KDBindings::makeBoundProperty](../Namespaces/namespaceKDBindings.md#function-makeboundproperty) for the different ways to create a binding.
+See [KDBindings::makeBoundProperty](../namespaceKDBindings.md#function-makeboundproperty) for the different ways to create a binding.
 
 We also recommend you take a look at our [examples](../examples.md).

--- a/docs/api/mkdocs/docs/getting-started/index.md
+++ b/docs/api/mkdocs/docs/getting-started/index.md
@@ -46,7 +46,7 @@ set(CMAKE_CXX_STANDARD 17)
 ### Including KDBindings
 Once the library is correctly added to your project, the different features of KDBindings are available for include under the `kdbindings` directory.
 
-All parts of KDBindings are then accessible in the [KDBindings namespace](../Namespaces/namespaceKDBindings.md).
+All parts of KDBindings are then accessible in the [KDBindings namespace](../namespaceKDBindings.md).
 ``` cpp
 // Example includes
 #include <kdbindings/signal.h>

--- a/docs/api/mkdocs/docs/getting-started/properties.md
+++ b/docs/api/mkdocs/docs/getting-started/properties.md
@@ -7,7 +7,7 @@ Unlike [Qts Properties](https://doc.qt.io/qt-5/properties.html), KDBindings Prop
 They can even be used outside of classes as free values.
 
 ## Declaring Properties
-Properties can be declared for most types by creating a [KDBindings::Property<T\>](../Classes/classKDBindings_1_1Property.md) instance.
+Properties can be declared for most types by creating a [KDBindings::Property<T\>](../classKDBindings_1_1Property.md) instance.
 
 The property instance will then emit [signals](signals-slots.md) every time the properties value changes, the property is moved or destructed.
 
@@ -29,4 +29,4 @@ Expected output:
 Hello World!
 ```
 
-For more information and examples see the [KDBindings::Property documentation](../Classes/classKDBindings_1_1Property.md).
+For more information and examples see the [KDBindings::Property documentation](../classKDBindings_1_1Property.md).

--- a/docs/api/mkdocs/docs/getting-started/signals-slots.md
+++ b/docs/api/mkdocs/docs/getting-started/signals-slots.md
@@ -40,7 +40,7 @@ Expected output:
 Hello World!
 ```
 
-For the full class reference, see: [KDBindings::Signal](../Classes/classKDBindings_1_1Signal.md).
+For the full class reference, see: [KDBindings::Signal](../classKDBindings_1_1Signal.md).
 
 ## KDBindings Slots
 In KDBindings, a slot is anything that can be invoked, so any function, lambda or other object that implements the `operator()`.
@@ -78,15 +78,15 @@ KDBindings expects the member function first, and the pointer to the class objec
 
 See the examples:
 
-- [02-signal-member](../Examples/02-signal-member_2main_8cpp-example.md)
-- [03-member-arguments](../Examples/03-member-arguments_2main_8cpp-example.md)
-- [07-advanced connections](../Examples/07-advanced-connections_2main_8cpp-example.md)
+- [02-signal-member](../02-signal-member_2main_8cpp-example.md)
+- [03-member-arguments](../03-member-arguments_2main_8cpp-example.md)
+- [07-advanced connections](../07-advanced-connections_2main_8cpp-example.md)
 
-Also see the [documentation of the connect function](../Classes/classKDBindings_1_1Signal.md#function-connect).
+Also see the [documentation of the connect function](../classKDBindings_1_1Signal.md#function-connect).
 
 ## Managing a connection
 
-Calling the connect function of a Signal returns a [KDBindings::ConnectionHandle](../Classes/classKDBindings_1_1ConnectionHandle.md).
+Calling the connect function of a Signal returns a [KDBindings::ConnectionHandle](../classKDBindings_1_1ConnectionHandle.md).
 These objects reference the connection and can be used to disconnect or temporarily block it.
 
 It's important to note that, unlike Qt, KDBindings requires you to manually disconnect a connection when any of the bound arguments are destroyed.
@@ -94,7 +94,7 @@ For that purpose it's important to keep the ConnectionHandle around!
 You must use it to disconnect the connection, should the object that contains the slot go out of scope!
 Otherwise, you will encounter a dangling pointer whenever the Signal is emitted.
 
-For further information, see the [KDBindings::ConnectionHandle](../Classes/classKDBindings_1_1ConnectionHandle.md) documentation.
+For further information, see the [KDBindings::ConnectionHandle](../classKDBindings_1_1ConnectionHandle.md) documentation.
 
 ## Some Notes on Mutability and const Best Practices
 

--- a/docs/api/mkdocs/mkdocs.yml.cmake
+++ b/docs/api/mkdocs/mkdocs.yml.cmake
@@ -1,5 +1,5 @@
 site_name: KDBindings ${CMAKE_PROJECT_VERSION} - Reactive programming & data binding in C++
-site_url: https://docs.kdab.com/kdbindings/${CMAKE_PROJECT_VERSION}/
+site_url: https://docs.kdab.com/kdbindings/latest/
 repo_url: https://github.com/kdab/kdbindings
 site_description: KDBindings Documentation - Reactive programming & data binding in C++
 site_author: Klarälvdalens Datakonsult AB (KDAB)


### PR DESCRIPTION
Note: Requires all doxybook output to be in the same folder.
However, now links from the /latest/ version will always also point to
/latest/.
Furthermore we can set all canonical links to point to /latest/. This
should improve our SEO for all pages where we have multiple versions.

As the links for our subpages have now changed, we should check that we don't have any outside links pointing to specific classes (i.e. in our blog posts) or set up redirects for any `Classes/`, `Namespaces/`, `Examples/` sub-links.

This might also warrant a change in the Minor version number, so that all old links to 1.0.0 docs still work.