### PR TITLE
Property: Remove noexcept from move constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_minimum_required(VERSION 3.12) # for `project(... HOMEPAGE_URL ...)`
 project(KDBindings
   DESCRIPTION "Bindings, from the comfort and speed of C++ and without Qt"
   LANGUAGES CXX
-  VERSION 1.0.0
+  VERSION 1.0.1
   HOMEPAGE_URL "https://github.com/KDAB/KDBindings"
 )
 

--- a/src/kdbindings/property.h
+++ b/src/kdbindings/property.h
@@ -168,7 +168,7 @@ public:
      * All data bindings that depend on this Property will update their references
      * to the newly move-constructed Property using this Signal.
      */
-    Property(Property<T> &&other) noexcept(std::is_nothrow_move_constructible<T>::value)
+    Property(Property<T> &&other)
         : m_value(std::move(other.m_value))
         , m_valueAboutToChange(std::move(other.m_valueAboutToChange))
         , m_valueChanged(std::move(other.m_valueChanged))
@@ -194,7 +194,7 @@ public:
     /**
      * See: Property(Property<T> &&other)
      */
-    Property &operator=(Property<T> &&other) noexcept(std::is_nothrow_move_assignable<T>::value)
+    Property &operator=(Property<T> &&other)
     {
         // We do not move the m_moved signal so that objects interested in the moved-into
         // property can recreate any connections they need.

--- a/tests/property/tst_property.cpp
+++ b/tests/property/tst_property.cpp
@@ -22,8 +22,11 @@ static_assert(std::is_nothrow_destructible<Property<int>>{});
 static_assert(std::is_default_constructible<Property<int>>{});
 static_assert(!std::is_copy_constructible<Property<int>>{});
 static_assert(!std::is_copy_assignable<Property<int>>{});
-static_assert(std::is_nothrow_move_constructible<Property<int>>{});
-static_assert(std::is_nothrow_move_assignable<Property<int>>{});
+// A property cannot be nothrow_move_assignable/constructible, as it emits
+// a moved Signal when moved. Any slot that is connected to this Signal may throw.
+static_assert(!std::is_nothrow_move_constructible<Property<int>>{});
+static_assert(!std::is_nothrow_move_assignable<Property<int>>{});
+
 
 struct CustomType {
     CustomType(int _a, uint64_t _b)


### PR DESCRIPTION
As @jm4R noted in #24, because a Property emits the moved signal when
moved, its move constructor cannot promise noexcept.

This also warrants a minor version bump to v1.0.1

This PR closes #24 