### PR TITLE
Property: Make moved Signal private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_minimum_required(VERSION 3.12) # for `project(... HOMEPAGE_URL ...)`
 project(KDBindings
   DESCRIPTION "Bindings, from the comfort and speed of C++ and without Qt"
   LANGUAGES CXX
-  VERSION 1.0.0
+  VERSION 1.0.1
   HOMEPAGE_URL "https://github.com/KDAB/KDBindings"
 )
 

--- a/src/kdbindings/node.h
+++ b/src/kdbindings/node.h
@@ -210,7 +210,7 @@ private:
     {
         m_property = &property;
         m_valueChangedHandle = m_property->valueChanged().connect(&PropertyNode<PropertyType>::markDirty, this);
-        m_movedHandle = m_property->moved().connect(&PropertyNode<PropertyType>::propertyMoved, this);
+        m_movedHandle = m_property->m_moved.connect(&PropertyNode<PropertyType>::propertyMoved, this);
         m_destroyedHandle = m_property->destroyed().connect(&PropertyNode<PropertyType>::propertyDestroyed, this);
     }
 

--- a/tests/property/tst_property.cpp
+++ b/tests/property/tst_property.cpp
@@ -295,39 +295,4 @@ TEST_CASE("Moving")
         REQUIRE(countValue == 1);
         REQUIRE(*(movedProperty.get()) == 123);
     }
-
-    SUBCASE("a property notifies when it has been moved into so we can recreate connections")
-    {
-        int countVoid = 0;
-        auto handlerVoid = [&countVoid]() { ++countVoid; };
-        Property<int> property{ 42 };
-
-        // Create a lambda we can use to create the initial connection and restore it
-        // when the property gets moved into (e.g. most likely when we assign a binding)
-        int countMoved = 0;
-        auto makeConnection = [&handlerVoid, &countMoved](const Property<int> &p) {
-            ++countMoved;
-            p.valueChanged().connect(handlerVoid);
-        };
-
-        // Create the initial connection
-        makeConnection(property);
-        REQUIRE(countMoved == 1);
-
-        // Ensure we get told about any moves
-        property.moved().connect(makeConnection);
-
-        // Change the property
-        property = 64;
-        REQUIRE(countVoid == 1);
-
-        // Move a new property into our original property
-        Property<int> property2{ 5 };
-        property = std::move(property2);
-        REQUIRE(countMoved == 2);
-
-        // Change the property again and our original lamba should get called still
-        property = 128;
-        REQUIRE(countVoid == 2);
-    }
 }


### PR DESCRIPTION
The moved Signal is problematic, as we can no longer guarantee `noexcept`
move behavior of Properties, if anyone is allowed to connect a slot to
the moved Signal. (See #24)

By making the moved Signal private within KDBindings, we can have
control over what code is executed by it. This allows us to keep the
noexcept guarantee on the Property move constructor/assignment.

This also warrants a version bump to v1.0.1

Note: I had to remove a test from tst_property.cpp which needed access to the moved Signal.
However, this is fine as the only behavior that the moved Signal can now influence is the observation by a PropertyNode.
This is tested in tst_node.cpp.

Closes #24 