### PR TITLE
Fix ScopedConnection not disconnecting old signals when assigned

### DIFF
--- a/src/kdbindings/signal.h
+++ b/src/kdbindings/signal.h
@@ -563,6 +563,7 @@ public:
      */
     ScopedConnection &operator=(ConnectionHandle &&h)
     {
+        m_connection.disconnect();
         m_connection = std::move(h);
         return *this;
     }

--- a/tests/signal/tst_signal.cpp
+++ b/tests/signal/tst_signal.cpp
@@ -518,6 +518,19 @@ TEST_CASE("ScopedConnection")
         REQUIRE(called);
     }
 
+    SUBCASE("A ScopedConnection disconnects when assigned")
+    {
+        int numCalled = 0;
+        Signal<> signal;
+        ScopedConnection guard = signal.connect([&numCalled]() { numCalled++; });
+        signal.emit();
+        CHECK_EQ(numCalled, 1);
+
+        guard = signal.connect([&numCalled]() { numCalled++; });
+        signal.emit();
+        CHECK_EQ(numCalled, 2);
+    }
+
     SUBCASE("A ScopedConnection can be moved")
     {
         bool called = false;


### PR DESCRIPTION
RAII classes release their resources when assigned.