### PR TITLE
Don't define docs target when option is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,10 +94,6 @@ endif()
 
 if(${PROJECT_NAME}_DOCS)
   add_subdirectory(docs) # needs to go last, in case there are build source files
-else()
-  add_custom_target(docs
-    COMMAND ${CMAKE_COMMAND} -E echo "Sorry, there is no docs target since KDBindings_DOCS=OFF."
-    "Re-run cmake with the -DKDBindings_DOCS=ON option if you want to generate the documentation.")
 endif()
 
 if(${PROJECT_NAME}_IS_ROOT_PROJECT)


### PR DESCRIPTION
Otherwise projects using KDBindings via fetchcontent will be
unable to declare their own docs target due to a name clash.