### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/kdbindings/node.h
+++ b/src/kdbindings/node.h
@@ -100,8 +100,8 @@ template<typename ResultType>
 class Node
 {
 public:
-    Node(std::unique_ptr<NodeInterface<ResultType>> &&interface)
-        : m_interface(std::move(interface))
+    Node(std::unique_ptr<NodeInterface<ResultType>> &&nodeInterface)
+        : m_interface(std::move(nodeInterface))
     {
     }
 


### PR DESCRIPTION
Rename 'interface' parameter to 'nodeInterface' to avoid compilation errors on Windows, where 'interface' is a predefined type in some system header.