### PR TITLE
Modify the copyright line to show the file creation year only

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,12 +4,12 @@ Upstream-Contact:  <info@kdab.com>
 Source: https://www.github.com/KDAB/KDBindings
 
 Files: *.json *.html *.md docs/api/Doxyfile.cmake docs/api/mkdocs/mkdocs.yml docs/api/mkdocs/docs/stylesheets/kdab.css
-Copyright: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #artwork
 Files: docs/api/*.png docs/api/mkdocs/docs/assets/*.svg
-Copyright: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #3rdparty cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Stay up-to-date with KDAB product announcements:
 
 Licensing
 =========
-KDBindings is (C) 2020-2021, Klarälvdalens Datakonsult AB, and is available under the
-terms of the [MIT](https://github.com/KDAB/KDBindings/blob/main/LICENSES/MIT.txt) license.
+KDBindings is © Klarälvdalens Datakonsult AB and available under the terms of
+the [MIT](https://github.com/KDAB/KDBindings/blob/main/LICENSES/MIT.txt) license.
 
 Contact KDAB at <info@kdab.com> if you need different licensing options.
 

--- a/cmake/KDBindingsConfig.cmake.in
+++ b/cmake/KDBindingsConfig.cmake.in
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Juan Casafranca <juan.casafranca@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Allen Winter <allen.winter@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Allen Winter <allen.winter@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/docs/api/footer.html
+++ b/docs/api/footer.html
@@ -1,7 +1,7 @@
     <hr>
     <div style="float: left;">
       <img src="kdab-logo-16x16.png">
-      <font style="font-weight: bold;">&copy; 2020-2021 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
+      <font style="font-weight: bold;">&copy; Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
       <br>
       "The Qt, C++ and OpenGL Experts"<br>
       <a href="https://www.kdab.com/">https://www.kdab.com/</a>

--- a/docs/api/mkdocs/docs/javascripts/config.js
+++ b/docs/api/mkdocs/docs/javascripts/config.js
@@ -1,3 +1,13 @@
+/*
+  This file is part of KDBindings.
+
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
 window.MathJax = {
     tex : {
         inlineMath : [ [ "\\(", "\\)" ] ],

--- a/docs/api/mkdocs/mkdocs.yml.cmake
+++ b/docs/api/mkdocs/mkdocs.yml.cmake
@@ -18,7 +18,7 @@ theme:
     text: 'Open Sans'
   favicon: assets/assets_logo_tree.svg
   logo: assets/transparentWhiteKDAB.svg
-copyright: "Copyright &copy; 2020-2023 Klar&auml;lvdalens Datakonsult AB (KDAB)<br>The Qt, C++ and OpenGL Experts<br><a href='https://www.kdab.com'>https://www.kdab.com/</a>"
+copyright: "Copyright &copy; Klar&auml;lvdalens Datakonsult AB (KDAB)<br>The Qt, C++ and OpenGL Experts<br><a href='https://www.kdab.com'>https://www.kdab.com/</a>"
 extra:
   # Disabling the generator notice is currently a
   # Insiders only feature.

--- a/examples/01-simple-connection/CMakeLists.txt
+++ b/examples/01-simple-connection/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/01-simple-connection/main.cpp
+++ b/examples/01-simple-connection/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/02-signal-member/CMakeLists.txt
+++ b/examples/02-signal-member/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/02-signal-member/main.cpp
+++ b/examples/02-signal-member/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/03-member-arguments/CMakeLists.txt
+++ b/examples/03-member-arguments/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/03-member-arguments/main.cpp
+++ b/examples/03-member-arguments/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/04-simple-property/CMakeLists.txt
+++ b/examples/04-simple-property/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/04-simple-property/main.cpp
+++ b/examples/04-simple-property/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/05-property-bindings/CMakeLists.txt
+++ b/examples/05-property-bindings/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/05-property-bindings/main.cpp
+++ b/examples/05-property-bindings/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/06-lazy-property-bindings/CMakeLists.txt
+++ b/examples/06-lazy-property-bindings/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/06-lazy-property-bindings/main.cpp
+++ b/examples/06-lazy-property-bindings/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/07-advanced-connections/CMakeLists.txt
+++ b/examples/07-advanced-connections/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Leon Matthes <leon.matthes@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/examples/07-advanced-connections/main.cpp
+++ b/examples/07-advanced-connections/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Leon Matthes <leon.matthes@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/src/kdbindings/CMakeLists.txt
+++ b/src/kdbindings/CMakeLists.txt
@@ -1,12 +1,11 @@
-# This file is part of KDBindings.
-#
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
+
 set(HEADERS
     binding.h
     binding_evaluator.h

--- a/src/kdbindings/binding.h
+++ b/src/kdbindings/binding.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/binding_evaluator.h
+++ b/src/kdbindings/binding_evaluator.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/make_node.h
+++ b/src/kdbindings/make_node.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/node.h
+++ b/src/kdbindings/node.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/node_functions.h
+++ b/src/kdbindings/node_functions.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/node_operators.h
+++ b/src/kdbindings/node_operators.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/property.h
+++ b/src/kdbindings/property.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/property_updater.h
+++ b/src/kdbindings/property_updater.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/signal.h
+++ b/src/kdbindings/signal.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/src/kdbindings/utils.h
+++ b/src/kdbindings/utils.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Leon Matthes <leon.matthes@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/binding/CMakeLists.txt
+++ b/tests/binding/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/binding/tst_binding.cpp
+++ b/tests/binding/tst_binding.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/node/CMakeLists.txt
+++ b/tests/node/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/node/tst_node.cpp
+++ b/tests/node/tst_node.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/property/CMakeLists.txt
+++ b/tests/property/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/property/tst_property.cpp
+++ b/tests/property/tst_property.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/signal/CMakeLists.txt
+++ b/tests/signal/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Sean Harmer <sean.harmer@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/signal/tst_signal.cpp
+++ b/tests/signal/tst_signal.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sean Harmer <sean.harmer@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDBindings.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Leon Matthes <leon.matthes@kdab.com>
 #
 # SPDX-License-Identifier: MIT

--- a/tests/utils/tst_gen_index_array.cpp
+++ b/tests/utils/tst_gen_index_array.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Leon Matthes <leon.matthes@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/utils/tst_get_arity.cpp
+++ b/tests/utils/tst_get_arity.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Leon Matthes <leon.matthes@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/tests/utils/tst_utils_main.cpp
+++ b/tests/utils/tst_utils_main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDBindings.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Leon Matthes <leon.matthes@kdab.com>
 
   SPDX-License-Identifier: MIT


### PR DESCRIPTION
Also: update copyright year for the entire project to 2024.

Per KDAB policy:
No longer show the year range of creationYear-currentYear. The creationYear is  enough.

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code