### PR TITLE
Avoid error in presence of Windows min/max macros

### DIFF
--- a/src/kdbindings/genindex_array.h
+++ b/src/kdbindings/genindex_array.h
@@ -66,7 +66,8 @@ public:
             return { index, m_entries[index].generation };
         } else {
             // check that we are still within the bounds of uint32_t
-            if (m_entries.size() + 1 >= std::numeric_limits<uint32_t>::max()) {
+            // (parentheses added to avoid Windows min/max macros)
+            if (m_entries.size() + 1 >= (std::numeric_limits<uint32_t>::max)()) {
                 throw std::length_error(std::string("Maximum number of values inside GenerationalIndexArray reached: ") + std::to_string(m_entries.size()));
             }
 


### PR DESCRIPTION
In theory we could relegate the responsibility of defining NOMINMAX to the users of KDBindings but as it's such a tiny change I rather carry it here and avoid the problem altogheter.