### PR TITLE
Fix Threads linking issue under Windows

### DIFF
--- a/tests/signal/CMakeLists.txt
+++ b/tests/signal/CMakeLists.txt
@@ -13,12 +13,17 @@ project(test-signal VERSION 0.1 LANGUAGES CXX)
 add_executable(${PROJECT_NAME}
     tst_signal.cpp
 )
+
+target_link_libraries(${PROJECT_NAME} KDAB::KDBindings)
+
 # For some reason, CMake with gcc doesn't automatically include the pthread library
 # when using std::thread. This is a workaround for that.
 # IMHO, this is ridiculous, std::thread is part of the standard library, it should just work
 # when I use C++, but it is what it is.
 # See: https://cmake.cmake.narkive.com/wWDhK9RQ/undefined-reference-to-pthread-create
-find_package (Threads)
-target_link_libraries(${PROJECT_NAME} KDAB::KDBindings ${CMAKE_THREAD_LIBS_INIT})
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    find_package (Threads)
+    target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 add_test(${PROJECT_NAME} ${PROJECT_NAME})


### PR DESCRIPTION
Only gcc needs the Threads library linked and it can't be correctly linked under windows, so add a check that we're compiling with gcc.