### PR TITLE
CI: Avoid duplicated CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@
 
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -13,25 +19,20 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-22.04
-          #- ubuntu-20.04
-          - windows-2022
-          #- windows-2019
-          - macos-12
-          #- macos-11
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-
-      - name: Create build directory
-        run: mkdir build
 
       - name: Install ninja-build tool
         uses: turtlesec-no/get-ninja@main
 
       - name: Make sure MSVC is found when Ninja generator is in use
         uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ runner.os == 'Windows' }}
 
       - name: Configure project
         run: cmake --preset=ci


### PR DESCRIPTION
Specifying the push/pull_request branch
avoids duplicated CI Jobs.