### PR TITLE
1.0 backport: Avoid error in presence of Windows min/max macros

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+* v1.0.4
+  - Avoid error in presence of Windows min/max macros (#63)
+  - Fix Clang-Tidy failures (#49)
+
+* v1.0.3
+  - Fix for Windows compilation error due to `interface` keyword (#40)
+
+* v1.0.2
+  - Make KDBINDINGS_DECLARE_FUNCTION callable outside of KDBindings namespace (#38)
+
 * v1.0.1
   - Property: Make moved Signal private (#24 & #26) - BREAKING!
   - Documentation: Small fixes & updates

--- a/src/kdbindings/genindex_array.h
+++ b/src/kdbindings/genindex_array.h
@@ -61,7 +61,8 @@ public:
             return { index, m_entries[index].generation };
         } else {
             // check that we are still within the bounds of uint32_t
-            if (m_entries.size() + 1 >= std::numeric_limits<uint32_t>::max()) {
+            // (parentheses added to avoid Windows min/max macros)
+            if (m_entries.size() + 1 >= (std::numeric_limits<uint32_t>::max)()) {
                 throw std::length_error(std::string("Maximum number of values inside GenerationalIndexArray reached: ") + std::to_string(m_entries.size()));
             }
 


### PR DESCRIPTION
In theory we could relegate the responsibility of defining NOMINMAX to the users of KDBindings but as it's such a tiny change I rather carry it here and avoid the problem altogheter.