### PR TITLE
Connect reflective: Allow slots to access their own ConnectionHandle

### DIFF
--- a/src/kdbindings/connection_handle.h
+++ b/src/kdbindings/connection_handle.h
@@ -177,13 +177,6 @@ public:
         return false;
     }
 
-    // Factory method to create a ConnectionHandle
-    static std::shared_ptr<ConnectionHandle> create(const std::weak_ptr<Private::SignalImplBase>& signalImpl, std::optional<Private::GenerationalIndex> id) {
-        auto handle = std::shared_ptr<ConnectionHandle>(new ConnectionHandle(signalImpl, id));
-        handle->self = handle; // Keep a weak reference to self
-        return handle;
-    }
-
 private:
     template<typename...>
     friend class Signal;
@@ -214,6 +207,14 @@ private:
             }
         }
         return nullptr;
+    }
+
+    // Factory method to create a ConnectionHandle
+    static std::shared_ptr<ConnectionHandle> create(const std::weak_ptr<Private::SignalImplBase> &signalImpl, std::optional<Private::GenerationalIndex> id)
+    {
+        auto handle = std::shared_ptr<ConnectionHandle>(new ConnectionHandle(signalImpl, id));
+        handle->self = handle; // Keep a weak reference to self
+        return handle;
     }
 };
 

--- a/src/kdbindings/connection_handle.h
+++ b/src/kdbindings/connection_handle.h
@@ -177,9 +177,18 @@ public:
         return false;
     }
 
+    // Factory method to create a ConnectionHandle
+    static std::shared_ptr<ConnectionHandle> create(const std::weak_ptr<Private::SignalImplBase>& signalImpl, std::optional<Private::GenerationalIndex> id) {
+        auto handle = std::shared_ptr<ConnectionHandle>(new ConnectionHandle(signalImpl, id));
+        handle->self = handle; // Keep a weak reference to self
+        return handle;
+    }
+
 private:
     template<typename...>
     friend class Signal;
+
+    std::weak_ptr<ConnectionHandle> self; // Allows for safe self-reference
 
     std::weak_ptr<Private::SignalImplBase> m_signalImpl;
     std::optional<Private::GenerationalIndex> m_id;

--- a/src/kdbindings/connection_handle.h
+++ b/src/kdbindings/connection_handle.h
@@ -181,8 +181,6 @@ private:
     template<typename...>
     friend class Signal;
 
-    std::weak_ptr<ConnectionHandle> self; // Allows for safe self-reference
-
     std::weak_ptr<Private::SignalImplBase> m_signalImpl;
     std::optional<Private::GenerationalIndex> m_id;
 
@@ -207,14 +205,6 @@ private:
             }
         }
         return nullptr;
-    }
-
-    // Factory method to create a ConnectionHandle
-    static std::shared_ptr<ConnectionHandle> create(const std::weak_ptr<Private::SignalImplBase> &signalImpl, std::optional<Private::GenerationalIndex> id)
-    {
-        auto handle = std::shared_ptr<ConnectionHandle>(new ConnectionHandle(signalImpl, id));
-        handle->self = handle; // Keep a weak reference to self
-        return handle;
     }
 };
 

--- a/src/kdbindings/signal.h
+++ b/src/kdbindings/signal.h
@@ -157,8 +157,7 @@ class Signal
         }
 
         // Disconnects all previously connected functions
-        void
-        disconnectAll()
+        void disconnectAll()
         {
             const auto numEntries = m_connections.entriesSize();
 

--- a/src/kdbindings/signal.h
+++ b/src/kdbindings/signal.h
@@ -272,34 +272,34 @@ public:
     }
 
     /**
-     * Establishes a connection between a signal and a slot, allowing the slot to access its own connection handle.
-     * This method is particularly useful for creating connections that can manage themselves, such as disconnecting
+     * Establishes a connection between a signal and a slot, allowing the slot to access and manage its own connection handle.
+     * This method is particularly useful for creating connections that can autonomously manage themselves, such as disconnecting
      * after being triggered a certain number of times or under specific conditions. It wraps the given slot function
-     * to include a shared pointer to the ConnectionHandle as the first parameter, enabling the slot to interact with
+     * to include a reference to the ConnectionHandle as the first parameter, enabling the slot to interact with
      * its own connection state directly.
      *
-     * @param slot A std::function that takes a shared_ptr<ConnectionHandle> followed by the signal's parameter types.
-     * @return A shared_ptr to the ConnectionHandle associated with this connection, allowing for advanced connection management.
+     * @param slot A std::function that takes a ConnectionHandle reference followed by the signal's parameter types.
+     * @return A ConnectionHandle to the newly established connection, allowing for advanced connection management.
      */
-    std::shared_ptr<ConnectionHandle> connectReflective(std::function<void(std::shared_ptr<ConnectionHandle>, Args...)> const &slot)
+    ConnectionHandle connectReflective(std::function<void(ConnectionHandle &, Args...)> const &slot)
     {
         ensureImpl();
 
-        // Create a placeholder handle (with no ID yet)
+        // Create a new ConnectionHandle with no ID initially. This handle will be used to manage the connection lifecycle.
         auto handle = ConnectionHandle::create(m_impl, std::nullopt);
 
-        auto wrappedSlot = [this, slot, weakHandle = std::weak_ptr<ConnectionHandle>(handle)](Args... args) {
-            if (auto handle = weakHandle.lock()) { // Ensure the handle is still valid
-                slot(handle, args...);
-            }
+        // Prepare the lambda that matches the signature expected by m_impl->connect
+        auto wrappedSlot = [this, handle, slot](Args... args) mutable {
+            // Directly invoke the user-provided slot with the handle and args
+            slot(*handle, args...);
         };
 
-        // Connect the wrapped slot
-        auto id = m_impl->connect(wrappedSlot);
+        // Connect the wrapped slot to the signal implementation.
+        // The handle ID is set after successful connection to manage this connection specifically.
+        handle->setId(m_impl->connect(wrappedSlot));
 
-        // Assign the ID to the handle now that it's known
-        handle->setId(id);
-        return handle;
+        // Return the ConnectionHandle, allowing the caller to manage the connection directly.
+        return *handle;
     }
 
     /**

--- a/tests/signal/tst_signal.cpp
+++ b/tests/signal/tst_signal.cpp
@@ -267,19 +267,21 @@ TEST_CASE("Signal connections")
         int val = 5;
 
         // Connect a reflective slot to the signal
-        auto handle = mySignal.connectReflective([&val](std::shared_ptr<ConnectionHandle> selfHandle, int value) {
+        auto handle = mySignal.connectReflective([&val](ConnectionHandle &selfHandle, int value) {
             val += value;
 
             // Disconnect after handling the signal once
-            selfHandle->disconnect();
+            selfHandle.disconnect();
         });
 
         mySignal.emit(5); // This should trigger the slot and then disconnect it
-        REQUIRE(!handle->isActive());
 
-        mySignal.emit(5); // Signal Already disconnected
+        REQUIRE(!handle.isActive());
 
-        REQUIRE(val == 10);
+        mySignal.emit(5); // Since the slot is disconnected, this should not affect 'val'
+
+        // Check if the value remains unchanged after the second emit
+        REQUIRE(val == 10); // 'val' was incremented once to 10 by the first emit and should remain at 10
     }
 
     SUBCASE("A signal with arguments can be connected to a lambda and invoked with l-value args")

--- a/tests/signal/tst_signal.cpp
+++ b/tests/signal/tst_signal.cpp
@@ -261,6 +261,27 @@ TEST_CASE("Signal connections")
         REQUIRE(anotherCalled);
     }
 
+    SUBCASE("Single Shot Connection")
+    {
+        Signal<int> mySignal;
+        int val = 5;
+
+        // Connect a reflective slot to the signal
+        auto handle = mySignal.connectReflective([&val](std::shared_ptr<ConnectionHandle> selfHandle, int value) {
+            val += value;
+
+            // Disconnect after handling the signal once
+            selfHandle->disconnect();
+        });
+
+        mySignal.emit(5); // This should trigger the slot and then disconnect it
+        REQUIRE(!handle->isActive());
+
+        mySignal.emit(5); // Signal Already disconnected
+
+        REQUIRE(val == 10);
+    }
+
     SUBCASE("A signal with arguments can be connected to a lambda and invoked with l-value args")
     {
         Signal<std::string, int> signal;

--- a/tests/signal/tst_signal.cpp
+++ b/tests/signal/tst_signal.cpp
@@ -284,6 +284,29 @@ TEST_CASE("Signal connections")
         REQUIRE(val == 10); // 'val' was incremented once to 10 by the first emit and should remain at 10
     }
 
+    SUBCASE("Self-blocking connection")
+    {
+        Signal<int> mySignal;
+        int val = 5;
+
+        auto handle = mySignal.connectReflective([&val](ConnectionHandle &self, int value) {
+            val += value;
+            self.block(true);
+        });
+
+        REQUIRE_FALSE(handle.isBlocked());
+        mySignal.emit(5);
+        REQUIRE(val == 10);
+        REQUIRE(handle.isBlocked());
+
+        mySignal.emit(5);
+        REQUIRE(val == 10);
+
+        handle.block(false);
+        mySignal.emit(5);
+        REQUIRE(val == 15);
+    }
+
     SUBCASE("A signal with arguments can be connected to a lambda and invoked with l-value args")
     {
         Signal<std::string, int> signal;


### PR DESCRIPTION
Follow up to #68 

This version now reuses the mechanism from connectDeferred that already created the appropriate ConnectionHandle.

Open Question: Can we make this compatible with connectDeferred somehow in a thread-safe manner?
This would be quite useful for single-shot signals across threads.