### PR TITLE
ci: Use windows-2019 instead of -latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
           - macos-latest
 
     steps:


### PR DESCRIPTION
We've been dealing with an issue in CI, where the test-signal test case
fails when building in Release mode on Windows.
It fails in the ConnectionEvaluator, when it tries to lock the mutex,
which is something that should simply not happen, as the shared_ptr in
the testcase keeps the ConnectionEvaluator alive at the point where the
crash occurs.

In addition, this problem is not reproducable anywhere outside Githubs
CI. If I copy the executable from Github Actions to my local machine,
it simply works.
This leads me to believe this is only a problem with this very specific
Windows environment.
By downgrading our Windows version in CI, we can avoid the problem and
at least continue development.

For context, the backtrace I was able to acquire:
```
=================================================================                                                                                                              
==4820==ERROR: AddressSanitizer: access-violation on unknown address 0x000000000000 (pc 0x7ffb09f03278 bp 0x11aeadaa0110 sp 0x0073330f8140 T0)
==4820==The signal is caused by a READ memory access.                                                                                                                          
==4820==Hint: address points to the zero page.
    #0 0x7ffb09f03277  (C:\Windows\SYSTEM32\MSVCP140.dll+0x180013277) 
    #1 0x7ff7ed7e0dc8 in std::_Mutex_base::lock(void) C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\mutex:52
    #2 0x7ff7ed7dae5f in std::lock_guard<std::mutex>::{ctor} C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\mutex:458 
    #3 0x7ff7ed7dae5f in KDBindings::ConnectionEvaluator::enqueueSlotInvocation(class KDBindings::ConnectionHandle const &, class std::function<(void)> const &) D:\a\KDBindings\KDBindings\src\kdbindings\connection_evaluator.h:75
    #4 0x7ff7ed79054a in <lambda_ae62dd9036462b42db68729ea8749e6d>::operator()(class KDBindings::ConnectionHandle const &, int) const D:\a\KDBindings\KDBindings\src\kdbindings\signal.h:104
    #5 0x7ff7ed7b76b2 in std::invoke C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\type_traits:1715 
    #6 0x7ff7ed7b76b2 in std::_Func_impl_no_alloc<class <lambda_ae62dd9036462b42db68729ea8749e6d>, void, class KDBindings::ConnectionHandle const &, int>::_Do_call(class KDBindings::ConnectionHandle const &, int &&) C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\functional:874
    #7 0x7ff7ed7d8499 in std::_Func_class<void,KDBindings::ConnectionHandle const &,int>::operator() C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\functional:917
    #8 0x7ff7ed7d8499 in KDBindings::Signal<int>::Impl::emit(int) D:\a\KDBindings\KDBindings\src\kdbindings\signal.h:200
    #9 0x7ff7ed796655 in KDBindings::Signal<int>::emit D:\a\KDBindings\KDBindings\src\kdbindings\signal.h:433
    #10 0x7ff7ed796655 in DOCTEST_ANON_FUNC_15 D:\a\KDBindings\KDBindings\tests\signal\tst_signal.cpp:118
    #11 0x7ff7ed7f1429 in doctest::Context::run(void) D:\a\KDBindings\KDBindings\tests\doctest\doctest.h:7007
    #12 0x7ff7ed804106 in main D:\a\KDBindings\KDBindings\tests\doctest\doctest.h:7085
    #13 0x7ff7ed80fefb in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #14 0x7ff7ed80fefb in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #15 0x7ffb16b54caf  (C:\Windows\System32\KERNEL32.DLL+0x180014caf)
    #16 0x7ffb180fe8aa  (C:\Windows\SYSTEM32\ntdll.dll+0x18007e8aa)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: access-violation (C:\Windows\SYSTEM32\MSVCP140.dll+0x180013277)
==4820==ABORTING
```