### PR TITLE
ci: Revert to Windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-2019
+          - windows-latest
           - macos-latest
 
     steps:


### PR DESCRIPTION
It seems the issues with the Windows runners have been fixed by Github