### PR TITLE
fix: Rename CMake KDBINDINGS_ENABLE_WARN_UNUSED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ include(FeatureSummary)
 option(${PROJECT_NAME}_TESTS "Build the tests" ON)
 option(${PROJECT_NAME}_EXAMPLES "Build the examples" ON)
 option(${PROJECT_NAME}_DOCS "Build the API documentation" OFF)
+option(${PROJECT_NAME}_ENABLE_WARN_UNUSED "Enable warnings for unused ConnectionHandles" ON)
 option(${PROJECT_NAME}_ERROR_ON_WARNING "Enable all compiler warnings and treat them as errors" OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/src/kdbindings/CMakeLists.txt
+++ b/src/kdbindings/CMakeLists.txt
@@ -6,8 +6,6 @@
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
 
-option(KDBINDINGS_ENABLE_WARN_UNUSED "Enable warnings for unused ConnectionHandles" ON)
-
 set(HEADERS
     binding.h
     binding_evaluator.h
@@ -37,7 +35,7 @@ set_target_properties(KDBindings PROPERTIES
   INTERFACE_COMPILE_FEATURES cxx_std_17
 )
 
-if(KDBINDINGS_ENABLE_WARN_UNUSED)
+if(KDBindings_ENABLE_WARN_UNUSED)
   target_compile_definitions(KDBindings INTERFACE KDBINDINGS_ENABLE_WARN_UNUSED=1)
 endif()
 


### PR DESCRIPTION
This options had a different capitalization from our other options. So bring it in line, at least in CMake.

For the preprocessor definition I think we should stick with the all caps naming.