### PR TITLE
Add a missing include in connection_evaluator.h

### DIFF
--- a/src/kdbindings/connection_evaluator.h
+++ b/src/kdbindings/connection_evaluator.h
@@ -10,6 +10,7 @@
 */
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <mutex>
 


### PR DESCRIPTION
We use std::remove_if in this header, yet <algorithm> wasn't included. In some circumstances (e.g. when running with clang-tidy on Ubuntu 24.04 on GitHub Actions) it triggered errors about unknown symbols.