### PR TITLE
Add noexcept specifiers where appropriate

### DIFF
--- a/src/kdbindings/connection_evaluator.h
+++ b/src/kdbindings/connection_evaluator.h
@@ -58,6 +58,8 @@ public:
      *
      * This function is responsible for evaluating and executing deferred connections.
      * This function is thread safe.
+     *
+     * @warning Evaluating slots that throw an exception is currently undefined behavior.
      */
     void evaluateDeferredConnections()
     {

--- a/src/kdbindings/signal.h
+++ b/src/kdbindings/signal.h
@@ -329,6 +329,10 @@ public:
      *
      * @return An instance of ConnectionHandle, that can be used to disconnect
      * or temporarily block the connection.
+     *
+     * @warning Connecting functions to a signal that throw an exception when called is currently undefined behavior.
+     * All connected functions should handle their own exceptions.
+     * For backwards-compatibility, the slot function is not required to be noexcept.
      */
     KDBINDINGS_WARN_UNUSED ConnectionHandle connect(std::function<void(Args...)> const &slot)
     {
@@ -346,6 +350,10 @@ public:
      *
      * @param slot A std::function that takes a ConnectionHandle reference followed by the signal's parameter types.
      * @return A ConnectionHandle to the newly established connection, allowing for advanced connection management.
+     *
+     * @warning Connecting functions to a signal that throw an exception when called is currently undefined behavior.
+     * All connected functions should handle their own exceptions.
+     * For backwards-compatibility, the slot function is not required to be noexcept.
      */
     ConnectionHandle connectReflective(std::function<void(ConnectionHandle &, Args...)> const &slot)
     {
@@ -371,6 +379,10 @@ public:
      * @note
      * The Signal class itself is not thread-safe. While the ConnectionEvaluator is inherently
      * thread-safe, ensure that any concurrent access to this Signal is protected externally to maintain thread safety.
+     *
+     * @warning Connecting functions to a signal that throw an exception when called is currently undefined behavior.
+     * All connected functions should handle their own exceptions.
+     * For backwards-compatibility, the slot function is not required to be noexcept.
      */
     KDBINDINGS_WARN_UNUSED ConnectionHandle connectDeferred(const std::shared_ptr<ConnectionEvaluator> &evaluator, std::function<void(Args...)> const &slot)
     {
@@ -410,6 +422,10 @@ public:
      * @return An instance of a Signal::ConnectionHandle that refers to this connection.
      *          Warning: When connecting a member function you must use the returned ConnectionHandle
      *          to disconnect when the object containing the slot goes out of scope!
+     *
+     * @warning Connecting functions to a signal that throw an exception when called is currently undefined behavior.
+     * All connected functions should handle their own exceptions.
+     * For backwards-compatibility, the slot function is not required to be noexcept.
      **/
     // The enable_if_t makes sure that this connect function specialization is only
     // available if we provide a function that cannot be otherwise converted to a

--- a/tests/signal/tst_signal.cpp
+++ b/tests/signal/tst_signal.cpp
@@ -45,7 +45,7 @@ static_assert(std::is_nothrow_default_constructible<ScopedConnection>{});
 static_assert(!std::is_copy_constructible<ScopedConnection>{});
 static_assert(!std::is_copy_assignable<ScopedConnection>{});
 static_assert(std::is_nothrow_move_constructible<ScopedConnection>{});
-static_assert(!std::is_nothrow_move_assignable<ScopedConnection>{});
+static_assert(std::is_nothrow_move_assignable<ScopedConnection>{});
 
 class Button
 {
@@ -513,6 +513,14 @@ TEST_CASE("ConnectionEvaluator")
         evaluator->evaluateDeferredConnections();
 
         REQUIRE(val == 6);
+
+        signal.emit(2);
+        REQUIRE(val == 6);
+
+        evaluator->evaluateDeferredConnections();
+        evaluator->evaluateDeferredConnections();
+
+        REQUIRE(val == 8);
     }
 
     SUBCASE("Disconnect deferred connection from deleted signal")


### PR DESCRIPTION
We can mark the following as `noexcept`:
- ~ScopedConnection
- ~Signal
- ConnectionHandle::disconnect
- several move constructors

There are some caveats though:
When disconnecting, we need to lock the mutex in the ConnectionEvaluator and allocate in the GenerationalIndexArray, which can both throw exceptions.
However, we currently do not have any out of memory guarantees in KDBindings, so terminating in that case should be a sufficient way of handling this case.
The same goes for when locking a mutex isn't possible. This likely indicates some kind of OS issue from which we can't really recover, so terminating is appropriate.

We could improve the situation by avoiding allocations in the GenerationalIndexArray when erasing slots.
This would be possible by using an inline linked-list inside the array to store free indices.
Which would save memory and would no longer require us to allocate memory when erasing entries.
However, it's also not trivial to implement, so leave this as a TODO.

Error checking in ConnectionEvaluator
-------------------------------------
This patch also adds some basic exception handling to the ConnectionEvaluator.
It is now somewhat protected from slots disconnecting themselves while they are evaluated and slots throwing exceptions.
However, this error-handling is rather basic and will simply **not** dequeue any slots while the evaluator is already evaluating and will dequeue all slots if any slot throws an exception. We could improve this situation by using a queue and popping elements 1-by-1 when evaluating without actually iterating over it. That way we could erase from the queue while its being evaluated. And when a slot throws, calling evaluate again could simply continue with the next slot, instead of skipping all queued slots.

However, we should ideally implement this queue as a ring-buffer to avoid excessive allocations by std::list or std::dequeu. But this isn't part of the STL, so would require us to roll our own ring-buffer implementation.

For now, this error handling isn't publicly documented and throwing within a slot or dequeuing while evaluating remains *undefined*, so that we can improve the situation in the future.