### PR TITLE
Add license file to repo root

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,8 @@
+License
+=======
+KDBindings is Copyright 2025 Klarälvdalens Datakonsult AB (KDAB),
+and is available under the terms of the MIT license.
+
+See REUSE.toml for licenses of included 3rdparty code.
+
+See the full license text in the LICENSES folder.


### PR DESCRIPTION
The files in LICENCES/ just have the texts and no copyright.
This normalizes KDBindings with other KDAB products.